### PR TITLE
Send SIGTERM to all processes in a group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,6 @@ test:
 	integration/test.sh
 	integration/ignore.sh
 	integration/restart.sh
+	integration/docker-term-all.sh
 
 .PHONY: release dist install clean-tox clean-pyc clean-build test

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,6 @@ test:
 	integration/ignore.sh
 	integration/restart.sh
 	integration/docker-term-all.sh
+	integration/errors.sh
 
 .PHONY: release dist install clean-tox clean-pyc clean-build test

--- a/captain_comeback/activity/engine.py
+++ b/captain_comeback/activity/engine.py
@@ -10,6 +10,7 @@ from tabulate import tabulate
 from captain_comeback.activity.messages import (NewCgroupMessage,
                                                 StaleCgroupMessage,
                                                 RestartCgroupMessage,
+                                                RestartTimeoutMessage,
                                                 ExitMessage)
 from captain_comeback.activity.status import PROC_STATUSES_RAW
 
@@ -63,6 +64,10 @@ class ActivityEngine(object):
 
                 for bit in bits:
                     self._log_activity(msg.cg.name(), bit)
+            elif isinstance(msg, RestartTimeoutMessage):
+                m = "container did not exit within {0} seconds grace " \
+                    "period".format(msg.grace_period)
+                self._log_activity(msg.cg.name(), m)
             elif isinstance(msg, ExitMessage):
                 logger.warning("shutting down")
                 break

--- a/captain_comeback/activity/messages.py
+++ b/captain_comeback/activity/messages.py
@@ -19,5 +19,11 @@ class RestartCgroupMessage(object):
         self.ps_table = ps_table
 
 
+class RestartTimeoutMessage(object):
+    def __init__(self, cg, grace_period):
+        self.cg = cg
+        self.grace_period = grace_period
+
+
 class ExitMessage(object):
     pass

--- a/captain_comeback/cli.py
+++ b/captain_comeback/cli.py
@@ -74,11 +74,16 @@ def run_loop(root_cg_path, activity_path, sync_target_interval,
 def restart_one(root_cg, grace_period, container_id):
     q = queue.Queue()
     cg = Cgroup(os.path.join(root_cg, container_id))
-    restart(grace_period, cg, q, q)
 
-    while not q.empty():
-        m = q.get()
-        logger.debug("%s: received %s", cg.name(), m.__class__.__name__)
+    try:
+        restart(grace_period, cg, q, q)
+    except IOError:
+        logger.error("%s: container does not exist", cg.name())
+        return 1
+    finally:
+        while not q.empty():
+            m = q.get()
+            logger.debug("%s: received %s", cg.name(), m.__class__.__name__)
 
     return 0
 

--- a/captain_comeback/restart/engine.py
+++ b/captain_comeback/restart/engine.py
@@ -4,6 +4,7 @@ import signal
 import logging
 import threading
 import subprocess
+import time
 
 import psutil
 
@@ -13,6 +14,9 @@ from captain_comeback.activity.messages import RestartCgroupMessage
 
 
 logger = logging.getLogger()
+
+
+RESTART_STATE_POLLS = 20
 
 
 class RestartEngine(object):
@@ -75,34 +79,58 @@ def restart(grace_period, cg, job_queue, activity_queue):
             # That process exited already. Who cares? We don't.
             logger.debug("%s: %s had already exited", cg.name(), pid)
 
-    restart_cmd = ["docker", "restart", "-t", str(grace_period), cg.name()]
-    proc = subprocess.Popen(restart_cmd, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    signaled_at = time.time()
 
-    # Try and allocate 10% of extra memory to give this cgroup a chance to
-    # shut down gracefully.
-    # NOTE: we look at free memory (rather than available) so that we don't
-    # have to e.g. free some buffers to grant this extra memory.
-    memory_limit = cg.memory_limit_in_bytes()
-    free_memory = psutil.virtual_memory().free
-    extra = int(memory_limit / 10)  # Make parameterizable
+    # All that follows is optimistic. In practice, the container could
+    # exit immediately and none of that would get a chance to run.
 
-    logger.debug("%s: memory_limit: %s, free_memory: %s, extra: %s",
-                 cg.name(), memory_limit, free_memory, extra)
-    if free_memory > extra:
-        new_limit = memory_limit + extra
-        logger.info("%s: increasing memory limit to %s", cg.name(),
-                    new_limit)
-        cg.set_memory_limit_in_bytes(new_limit)
+    try:
+        # Try and allocate 10% of extra memory to give this cgroup a chance to
+        # shut down gracefully. Note that we look at free memory (rather than
+        # available) so that we don't have to e.g. free some buffers to grant
+        # this extra memory.
+        memory_limit = cg.memory_limit_in_bytes()
+        free_memory = psutil.virtual_memory().free
+        extra = int(memory_limit / 10)  # Make parameterizable
 
-    out, err = proc.communicate()
-    ret = proc.poll()
-    if ret != 0:
-        logger.error("%s: failed to restart", cg.name())
-        logger.error("%s: status: %s", cg.name(), ret)
-        logger.error("%s: stdout: %s", cg.name(), out)
-        logger.error("%s: stderr: %s", cg.name(), err)
+        logger.debug("%s: memory_limit: %s, free_memory: %s, extra: %s",
+                     cg.name(), memory_limit, free_memory, extra)
+        if free_memory > extra:
+            new_limit = memory_limit + extra
+            logger.info("%s: increasing memory limit to %s", cg.name(),
+                        new_limit)
+            cg.set_memory_limit_in_bytes(new_limit)
 
-    # TODO: Make this a finally?
-    logger.info("%s: restart complete", cg.name())
-    job_queue.put(RestartCompleteMessage(cg))
+        # Now, we give grace_period to the container to exit. We'd like to use
+        # docker restart -t for this, but unfortunately that does not work
+        # reliably: https://github.com/docker/docker/issues/12738
+        while time.time() < signaled_at + grace_period:
+            time.sleep(float(grace_period) / RESTART_STATE_POLLS)
+            try:
+                pids = cg.pids()
+            except EnvironmentError:
+                # The cgroup is gone!
+                logger.debug("%s: cgroup has exited after SIGTERM ", cg.name())
+                break
+            else:
+                logger.debug("%s: Waiting for processes to exit: %s...",
+                             cg.name(), ", ".join(str(p) for p in pids))
+    except EnvironmentError:
+        # This could happen if e.g. attempting to write to the memory limit
+        # file after the cgroup has exited.
+        pass
+    finally:
+        restart_cmd = ["docker", "restart", "-t", "0", cg.name()]
+        proc = subprocess.Popen(restart_cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
+        out, err = proc.communicate()
+        ret = proc.poll()
+        if ret != 0:
+            logger.error("%s: failed to restart", cg.name())
+            logger.error("%s: status: %s", cg.name(), ret)
+            logger.error("%s: stdout: %s", cg.name(), out)
+            logger.error("%s: stderr: %s", cg.name(), err)
+
+        logger.info("%s: restart complete", cg.name())
+        job_queue.put(RestartCompleteMessage(cg))

--- a/captain_comeback/restart/engine.py
+++ b/captain_comeback/restart/engine.py
@@ -120,6 +120,10 @@ def restart(grace_period, cg, job_queue, activity_queue):
             else:
                 logger.debug("%s: Waiting for processes to exit: %s...",
                              cg.name(), ", ".join(str(p) for p in pids))
+        else:
+            logger.warning(
+                "%s: container did not exit within %s seconds grace period",
+                cg.name(), grace_period)
     except EnvironmentError:
         # This could happen if e.g. attempting to write to the memory limit
         # file after the cgroup has exited.

--- a/captain_comeback/restart/engine.py
+++ b/captain_comeback/restart/engine.py
@@ -11,7 +11,8 @@ import psutil
 
 from captain_comeback.restart.messages import (RestartRequestedMessage,
                                                RestartCompleteMessage)
-from captain_comeback.activity.messages import RestartCgroupMessage
+from captain_comeback.activity.messages import (RestartCgroupMessage,
+                                                RestartTimeoutMessage)
 
 
 logger = logging.getLogger()
@@ -124,6 +125,7 @@ def restart(grace_period, cg, job_queue, activity_queue):
             logger.warning(
                 "%s: container did not exit within %s seconds grace period",
                 cg.name(), grace_period)
+            activity_queue.put(RestartTimeoutMessage(cg, grace_period))
     except EnvironmentError:
         # This could happen if e.g. attempting to write to the memory limit
         # file after the cgroup has exited.

--- a/captain_comeback/test/activity_test_unit.py
+++ b/captain_comeback/test/activity_test_unit.py
@@ -14,6 +14,7 @@ from captain_comeback.activity.engine import ActivityEngine
 from captain_comeback.activity.messages import (NewCgroupMessage,
                                                 StaleCgroupMessage,
                                                 RestartCgroupMessage,
+                                                RestartTimeoutMessage,
                                                 ExitMessage)
 
 
@@ -74,6 +75,14 @@ class ActivityTestUnit(unittest.TestCase):
             "container is restarting:",
             re.compile(r"123\s+16\s+8\s+T\s+some proc"),
             re.compile(r'456\s+4\s+2\s+R\s+sh -c "a && b"')
+        ])
+
+    def test_restart_timeout(self):
+        self.q.put(RestartTimeoutMessage(Cgroup("/some/foo"), 3))
+        self.q.put(ExitMessage())
+        self.engine.run()
+        self.assertHasLogged("foo", [
+            "container did not exit within 3 seconds grace period"
         ])
 
     def assertHasLogged(self, cg_name, messages):

--- a/captain_comeback/test/queue_assertion_helper.py
+++ b/captain_comeback/test/queue_assertion_helper.py
@@ -5,12 +5,14 @@ from six.moves import queue
 class QueueAssertionHelper(object):
     ANY_CG = object()
 
-    def assertHasMessageForCg(self, q, message_class, cg_path):
+    def assertHasMessageForCg(self, q, message_class, cg_path, **attrs):
         msg = q.get_nowait()
         self.assertIsInstance(msg, message_class)
         if cg_path is self.ANY_CG:
             return
         self.assertEqual(cg_path, msg.cg.path)
+        for k, v in attrs.items():
+            self.assertEqual(v, getattr(msg, k))
 
     def assertHasNoMessages(self, q):
         self.assertRaises(queue.Empty, q.get_nowait)

--- a/integration/docker-term-all.sh
+++ b/integration/docker-term-all.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This test just checks that sending SIGTERM to all the PIDS in a container and
+# restarting it at a later time (once it has exited) still brings the container
+# back up with ports.
+set -o errexit
+set -o nounset
+
+REL_HERE=$(dirname "${BASH_SOURCE}")
+HERE=$(cd "${REL_HERE}"; pwd)
+cd "$HERE"
+. lib.sh
+
+TEST_PORT=4628
+
+echo "Running container"
+cid="$(docker run -d --publish "$TEST_PORT":80 alpine sh -c 'httpd -f')"
+
+echo "Checking port ${TEST_PORT} is listening"
+wait_for curl -s "http://127.0.0.1:${TEST_PORT}" >/dev/null
+
+echo "Killing everything with SIGTERM"
+kill -TERM $(cat "/sys/fs/cgroup/memory/docker/${cid}/tasks")
+
+echo "Waiting for container to exit"
+container_exited() {
+  [[ "$(docker inspect -f "{{.State.Running}}" "$cid")" = "false" ]]
+}
+wait_for container_exited
+
+echo "Restarting"
+docker restart "$cid"
+
+echo "Checking port ${TEST_PORT} is listening"
+curl -s "http://127.0.0.1:${TEST_PORT}" >/dev/null
+
+docker rm -f "$cid" 2>/dev/null
+echo "SUCCESS"

--- a/integration/docker-term-all.sh
+++ b/integration/docker-term-all.sh
@@ -14,24 +14,18 @@ TEST_PORT=4628
 
 echo "Running container"
 cid="$(docker run -d --publish "$TEST_PORT":80 alpine sh -c 'httpd -f')"
+cleanup() {
+  docker rm -f "$cid" >/dev/null 2>&1
+}
+trap cleanup EXIT
 
 echo "Checking port ${TEST_PORT} is listening"
 wait_for curl -s "http://127.0.0.1:${TEST_PORT}" >/dev/null
 
-echo "Killing everything with SIGTERM"
-kill -TERM $(cat "/sys/fs/cgroup/memory/docker/${cid}/tasks")
-
-echo "Waiting for container to exit"
-container_exited() {
-  [[ "$(docker inspect -f "{{.State.Running}}" "$cid")" = "false" ]]
-}
-wait_for container_exited
-
-echo "Restarting"
-docker restart "$cid"
+echo "Restarting container"
+captain-comeback --restart "$cid"
 
 echo "Checking port ${TEST_PORT} is listening"
 curl -s "http://127.0.0.1:${TEST_PORT}" >/dev/null
 
-docker rm -f "$cid" 2>/dev/null
 echo "SUCCESS"

--- a/integration/errors.sh
+++ b/integration/errors.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This test checks error handling in the CLI.
+
+echo "Checking status code on bogus restart"
+captain-comeback --restart foo >/dev/null 2>&1
+if [[ "$?" != 1 ]]; then
+  echo "Restarting a bogus container did not exit with 1!"
+  exit 1
+fi
+echo "Status OK"
+
+echo "Checking error message on bogus restart"
+captain-comeback --restart foo 2>&1 \
+  | grep -qE "ERROR.+foo.+does not exist"
+if [[ "$?" != 0 ]]; then
+  echo "Restarting a bogus container did not print an error"
+  exit 1
+fi
+echo "Error OK"
+
+echo "Checking warning on timeout"
+cid="$(docker run -d alpine sleep 100)"
+trap 'docker rm -f "$cid" >/dev/null 2>&1' EXIT
+captain-comeback --restart "$cid" --restart-grace-period 1 2>&1 \
+  | grep -qE "WARN.+${cid}.+did not exit"
+if [[ "$?" != 0 ]]; then
+  echo "Timing out on restart did not print a warning"
+  exit 1
+fi
+echo "Warning OK"

--- a/integration/lib.sh
+++ b/integration/lib.sh
@@ -27,6 +27,8 @@ want_hog() {
 
 
 _run_hog_internal() {
+  docker rm "$HOG_CONTAINER_NAME" >/dev/null 2>&1 || true
+
   local opts=("--memory" "$HOG_MEMORY_LIMIT"
         "--name" "$HOG_CONTAINER_NAME"
         "-v" "$(pwd):/hog"
@@ -40,7 +42,7 @@ _run_hog_internal() {
 }
 
 run_hog_fg() {
-  _run_hog_internal "--rm"
+  _run_hog_internal
 }
 
 run_hog_bg() {
@@ -77,4 +79,15 @@ run_captain_bg() {
   CAPTAIN_PID="$!"
   CAPTAIN_TERMINATED=0
   terminate_captain_at_exit
+}
+
+wait_for() {
+  for i in $(seq 0 50); do
+    if "$@" ; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  return 1
 }


### PR DESCRIPTION
Aptible interprets Procfiles with a shell, which means that for most
containers (i.e. unless they were designed to work around this problem),
PID 1 will be a shell that will dutyfully ignore the SIGTERM we send
when attempting to restart the container.

This is problematic, because it reduces our chances of getting a clean
restart by not letting running processes e.g. clean up their PID files.

So, to increase our odds of success, we send SIGTERM to everyone in the
container (like e.g. Heroku does).

--

cc @fancyremarker @blakepettersson 