### PR TITLE
Activity: List processes, not threads

### DIFF
--- a/captain_comeback/cgroup.py
+++ b/captain_comeback/cgroup.py
@@ -99,8 +99,8 @@ class Cgroup(object):
             f.write("\n")
 
     def pids(self):
-        with open(self._tasks_file_path()) as f:
-            return [int(t) for t in f.readlines()]
+        with open(self._procs_file_path()) as f:
+            return set(int(t) for t in f.readlines())
 
     def ps_table(self):
         # Take a snapshot of the processes in this cgroup, which will be usable
@@ -124,5 +124,5 @@ class Cgroup(object):
     def _memory_limit_file_path(self):
         return os.path.join(self.path, "memory.limit_in_bytes")
 
-    def _tasks_file_path(self):
-        return os.path.join(self.path, "tasks")
+    def _procs_file_path(self):
+        return os.path.join(self.path, "cgroup.procs")


### PR DESCRIPTION
The tasks file in a cgroup contains (as you'd expect..!) a list of the
tasks present in this cgroup. But, tasks (and PIDs..!) represent
threads, not processes, which creates a few problems when dealing with
multi-threaded programs:

- When we send `SIGTERM` using a PID, that signal actually gets
  delivered to the process (not the thread!), so we end up signalling
  processes multiple times if they have multiple threads.
- When we log processes running a cgroup, we end up logging the same
  process over and over (once for each of its threads), which turns out
  to be very inefficient (there might be *a lot* of threads) as well as
  confusing. We've seen cases where it took maybe 10 seconds to log all
  threads.

---

cc @fancyremarker @blakepettersson 