### PR TITLE
Wipe (backup) container FS on restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,6 @@ test:
 	integration/restart.sh
 	integration/docker-term-all.sh
 	integration/errors.sh
+	integration/wipe.sh
 
 .PHONY: release dist install clean-tox clean-pyc clean-build test

--- a/captain_comeback/test/restart_test_integration.py
+++ b/captain_comeback/test/restart_test_integration.py
@@ -21,6 +21,10 @@ CG_DOCKER_ROOT_DIR = "/sys/fs/cgroup/memory/docker/"
 
 EXITS_WITH_TERM_1 = ["krallin/ubuntu-tini", "sleep", "100"]
 EXITS_WITH_TERM_ALL = ["ubuntu", "sh", "-c", "sleep 100"]
+EXITS_IF_FILE = [
+    "ubuntu", "sh", "-c",
+    "if test -f foo; then exit 1; else touch foo && sleep 100; fi"
+]
 NEVER_EXITS = ["ubuntu", "sleep", "100"]  # No default sighanders as PID 1
 
 
@@ -65,7 +69,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         cg = self._launch_container(EXITS_WITH_TERM_1)
         job_q = queue.Queue()
         activity_q = queue.Queue()
-        restart(10, cg, job_q, activity_q)
+        restart(10, False, cg, job_q, activity_q)
 
         self.assertHasMessageForCg(job_q, RestartCompleteMessage, cg.path)
         self.assertHasMessageForCg(activity_q, RestartCgroupMessage, cg.path)
@@ -75,7 +79,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         cg = self._launch_container(NEVER_EXITS)
         job_q = queue.Queue()
         activity_q = queue.Queue()
-        restart(3, cg, job_q, activity_q)
+        restart(3, False, cg, job_q, activity_q)
 
         self.assertHasMessageForCg(job_q, RestartCompleteMessage, cg.path)
         self.assertHasMessageForCg(activity_q, RestartCgroupMessage, cg.path)
@@ -89,7 +93,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         time_before = time.time()
 
         q = queue.Queue()
-        restart(10, cg, q, q)
+        restart(10, False, cg, q, q)
 
         time_after = time.time()
         pid_after = docker_json(cg)["State"]["Pid"]
@@ -104,7 +108,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         time_before = time.time()
 
         q = queue.Queue()
-        restart(10, cg, q, q)
+        restart(10, False, cg, q, q)
 
         time_after = time.time()
         pid_after = docker_json(cg)["State"]["Pid"]
@@ -119,7 +123,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         time_before = time.time()
 
         q = queue.Queue()
-        restart(3, cg, q, q)
+        restart(3, False, cg, q, q)
 
         time_after = time.time()
         pid_after = docker_json(cg)["State"]["Pid"]
@@ -133,16 +137,39 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         options = ["-p", "{0}:80".format(host_port)] + EXITS_WITH_TERM_1
         cg = self._launch_container(options)
         q = queue.Queue()
-        restart(10, cg, q, q)
+        restart(10, False, cg, q, q)
 
         binding = docker_json(cg)["NetworkSettings"]["Ports"]["80/tcp"][0]
         port = int(binding["HostPort"])
 
         self.assertEqual(host_port, port)
 
+    def test_restart_does_not_wipe_fs(self):
+        q = queue.Queue()
+
+        cg = self._launch_container(EXITS_IF_FILE)
+        time.sleep(2)
+
+        restart(0, False, cg, q, q)
+        time.sleep(2)
+
+        self.assertFalse(docker_json(cg)["State"]["Running"])
+
+    @unittest.skipUnless(os.geteuid() == 0, "requires root")
+    def test_restart_wipes_fs(self):
+        q = queue.Queue()
+
+        cg = self._launch_container(EXITS_IF_FILE)
+        time.sleep(2)
+
+        restart(0, True, cg, q, q)
+        time.sleep(2)
+
+        self.assertTrue(docker_json(cg)["State"]["Running"])
+
     @unittest.skipUnless(os.geteuid() == 0, "requires root")
     def test_restart_with_memory_limit(self):
         options = ["--memory", "10mb"] + EXITS_WITH_TERM_1
         cg = self._launch_container(options)
         q = queue.Queue()
-        restart(10, cg, q, q)
+        restart(10, False, cg, q, q)

--- a/captain_comeback/test/restart_test_integration.py
+++ b/captain_comeback/test/restart_test_integration.py
@@ -150,7 +150,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         cg = self._launch_container(EXITS_IF_FILE)
         time.sleep(2)
 
-        restart(0, False, cg, q, q)
+        restart(1, False, cg, q, q)
         time.sleep(2)
 
         self.assertFalse(docker_json(cg)["State"]["Running"])
@@ -162,7 +162,7 @@ class RestartTestIntegration(unittest.TestCase, QueueAssertionHelper):
         cg = self._launch_container(EXITS_IF_FILE)
         time.sleep(2)
 
-        restart(0, True, cg, q, q)
+        restart(1, True, cg, q, q)
         time.sleep(2)
 
         self.assertTrue(docker_json(cg)["State"]["Running"])

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -2,8 +2,6 @@
 set -o errexit
 set -o nounset
 
-# TODO: Add check for swapoff?
-
 REL_HERE=$(dirname "${BASH_SOURCE}")
 HERE=$(cd "${REL_HERE}"; pwd)
 cd "$HERE"
@@ -28,7 +26,7 @@ HOG_END_MS="$(date +%s%3N)"
 echo "Exit hog: $(date)"
 
 # Start the captain
-run_captain_bg --restart-grace-period "$RESTART_TIMEOUT_S"
+run_captain_bg --restart-grace-period "$RESTART_TIMEOUT_S" --wipe-fs
 
 # Run the hog
 echo "Start test: $(date)"

--- a/integration/wipe.sh
+++ b/integration/wipe.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+REL_HERE=$(dirname "${BASH_SOURCE}")
+HERE=$(cd "${REL_HERE}"; pwd)
+cd "$HERE"
+. lib.sh
+
+want_root
+cid="$(docker run -d alpine sh -c 'if test -f foo; then exit 1; else touch foo && sleep 100; fi')"
+
+captain-comeback --restart-grace-period 1 --wipe-fs --restart "$cid"
+
+sleep 2
+docker top "$cid" # Container should NOT have exited by now
+
+docker rm -f "$cid"
+
+# File should have been backed up
+find "/var/lib/docker/.captain-comeback-backup/${cid}/" | grep foo

--- a/integration/wipe.sh
+++ b/integration/wipe.sh
@@ -8,14 +8,21 @@ cd "$HERE"
 . lib.sh
 
 want_root
+
+echo "Test new files are deleted"
 cid="$(docker run -d alpine sh -c 'if test -f foo; then exit 1; else touch foo && sleep 100; fi')"
-
 captain-comeback --restart-grace-period 1 --wipe-fs --restart "$cid"
-
 sleep 2
 docker top "$cid" # Container should NOT have exited by now
-
 docker rm -f "$cid"
 
 # File should have been backed up
 find "/var/lib/docker/.captain-comeback-backup/${cid}/" | grep foo
+
+
+echo "Test deleted files are restored"
+cid="$(docker run -d alpine sh -c 'if test -d /var/log; then rm -r /var/log && sleep 100; else exit 1; fi')"
+captain-comeback --restart-grace-period 1 --wipe-fs --restart "$cid"
+sleep 2
+docker top "$cid" # Container should NOT have exited by now
+docker rm -f "$cid"


### PR DESCRIPTION
This will prevent containers from failing to restart due to e.g. PID
files laying around, and generally speaking more closely with how
customers expect containers to restart (i.e. as if the app itself had
been restarted).

This functionality is being a --wipe-fs, and it'll make sense to only
enable it on hosts where we *need* to wipe filesystems clean before
restarting (i.e. app instances, as opposed to DB instances where we know
the only images running there will recover gracefully).

---

cc @fancyremarker 