### PR TITLE
Store CC backups under /var/lib/docker/aufs

### DIFF
--- a/captain_comeback/restart/engine.py
+++ b/captain_comeback/restart/engine.py
@@ -7,7 +7,6 @@ import subprocess
 import time
 import errno
 import uuid
-import shutil
 
 import psutil
 
@@ -16,17 +15,18 @@ from captain_comeback.restart.messages import (RestartRequestedMessage,
 from captain_comeback.activity.messages import (RestartCgroupMessage,
                                                 RestartTimeoutMessage)
 
-AUFS_DIFF_DIR = "/var/lib/docker/aufs/diff"
-AUFS_MNT_DIR = "/var/lib/docker/aufs/mnt"
+AUFS_BASE_DIR = "/var/lib/docker/aufs"
+
+AUFS_DIFF_DIR = os.path.join(AUFS_BASE_DIR, "diff")
+AUFS_MNT_DIR = os.path.join(AUFS_BASE_DIR, "mnt")
 
 AUFS_MOUNTS_DIR = "/var/lib/docker/image/aufs/layerdb/mounts"
 AUFS_MOUNT_FILE = "mount-id"
 
-BACKUP_DIR = "/var/lib/docker/.captain-comeback-backup"
+BACKUP_DIR = os.path.join(AUFS_BASE_DIR, "captain-comeback-backup")
 
 
 logger = logging.getLogger()
-
 
 RESTART_STATE_POLLS = 20
 
@@ -209,11 +209,11 @@ def do_wipe_fs(cg):
         raise
     logger.info("%s: rename: done: %s", cg.name(), restore_id)
 
-    backup = os.path.join(BACKUP_DIR, cg.name(), restore_id)
+    backup = os.path.join(BACKUP_DIR, "{0}-{1}".format(cg.name(), restore_id))
     logger.info("%s: backup to: %s", cg.name(), backup)
 
     mkdir_p(os.path.dirname(backup))
-    shutil.move(aufs_outbound, backup)
+    os.rename(aufs_outbound, backup)
 
 
 def try_exec_and_wait(cg, *command):

--- a/integration/wipe.sh
+++ b/integration/wipe.sh
@@ -17,7 +17,7 @@ docker top "$cid" # Container should NOT have exited by now
 docker rm -f "$cid"
 
 # File should have been backed up
-find "/var/lib/docker/.captain-comeback-backup/${cid}/" | grep foo
+find "/var/lib/docker/aufs/captain-comeback-backup/${cid}-"* | grep foo
 
 
 echo "Test deleted files are restored"


### PR DESCRIPTION
/var/lib/docker/aufs is mounted as its own volume on our instances, so
moving things over to `/var/lib/docker/.captain-comeback-backup` means
we have to copy them, which is not ideal because:

- It can fail if we run out of disk space or if we hit things that
  `shutil.move` doesn't know how to handle (e.g. named pipes).
- It can be slow if there's a lot of data to copy.
- It's not transactional so we can't tell the difference between a
  backup that's being moved and a backup that's been moved.

There's no fundamental reason to put these backups under
`/var/lib/docker` anyway, so let's just put them under
`/var/lib/docker/aufs`, and use a simple `os.rename` to move data over,
which is much less likely to fail, instant, and transactional.

Note that this *will* fail if `/var/lib/docker/aufs/diff` and
`/var/lib/docker/aufs/captain-comeback-backup` are on different devices,
but that's not something we need / want to support.

---

cc @fancyremarker - this will change a couple things regarding our storage structure and strategy when freeing up disk space:
 
- `/var/lib/docker/.captain-comeback-backup` will always be safe to delete since we won't use it anymore.
- Any directory under `/var/lib/aufs/captain-comeback-backup` is safe to delete (because moves will be transactional), but try to avoid deleting `/var/lib/aufs/captain-comeback-backup` itself (doing so wouldn't be a major issue, but if there are any containers being restarted then their backup may end up being left around in `/var/lib/aufs/diff`).

Note that I've opted not to move the container data directly to the backup directory so that we fail gracefully in the event that `/var/lib/docker/aufs/diff` is its own device, but as I noted in the commit above, that shouldn't be the case on our own infrastructure.