### PR TITLE
Retry docker stop and docker restart

### DIFF
--- a/captain_comeback/test/engine_test_unit.py
+++ b/captain_comeback/test/engine_test_unit.py
@@ -1,0 +1,39 @@
+# coding:utf-8
+import unittest
+import tempfile
+import shutil
+
+from captain_comeback.cgroup import Cgroup
+from captain_comeback.restart import engine
+
+
+class EngineTestUnit(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_try_exec_and_wait_retry(self):
+        # This script requires running twice to succeed
+        test_file = "{0}/foo".format(self.test_dir)
+        shell = 'if test -f {0};' \
+                'then exit 0; ' \
+                'else touch {0} && exit 1; ' \
+                'fi'.format(test_file, test_file)
+
+        cmd = ['sh', '-c', shell]
+        ret = engine.try_exec_and_wait(Cgroup("/some/foo"), *cmd)
+        self.assertTrue(ret)
+
+    def test_try_exec_and_wait_without_retry(self):
+        # This script will not succeed if run twice
+        test_file = "{0}/foo".format(self.test_dir)
+        shell = 'if test -f {0};' \
+                'then exit 1; ' \
+                'else touch {0} && exit 0; ' \
+                'fi'.format(test_file, test_file)
+
+        cmd = ['sh', '-c', shell]
+        ret = engine.try_exec_and_wait(Cgroup("/some/foo"), *cmd)
+        self.assertTrue(ret)


### PR DESCRIPTION
On Docker 1.6, we occasionally seem to hit a race condition in Docker
that prevents us from stopping or restarting a container immediately
after it exits.

This seems to happen because Docker gets a little confused about the
state of the container: Docker thinks it's running, but it's actually
dead.

It's unclear exactly how long it takes for the container to become
usable again, but looking at the Docker logs, there's a good chance that
it's just a few seconds until Docker realizes the container has exited.

So, this patch updates Captain Comeback so that it retries stopping and
restarting the container for a little while.

---

cc @fancyremarker 