### PR TITLE
Don't show RAM usage in scientific notation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ install:
   - gosu root make install
   - gosu root pip install -r test_requirements.txt
 script:
+  - docker run -i --rm alpine true
   - gosu root make test

--- a/captain_comeback/activity/engine.py
+++ b/captain_comeback/activity/engine.py
@@ -47,8 +47,8 @@ class ActivityEngine(object):
                     [
                         pinfo["pid"],
                         pinfo["ppid"],
-                        pinfo["memory_info"].vms / KB,
-                        pinfo["memory_info"].rss / KB,
+                        int(pinfo["memory_info"].vms / KB),
+                        int(pinfo["memory_info"].rss / KB),
                         PROC_STATUSES_RAW.get(pinfo['status']) or "?",
                         subprocess.list2cmdline(pinfo["cmdline"])
                     ]


### PR DESCRIPTION
Prefer this table:

```
PID    PPID      VSZ      RSS  STAT    COMMAND
123       0  2097152  2097152  R       some proc
```

To this one:

```
PID    PPID          VSZ          RSS  STAT    COMMAND
123       0  2.09715e+06  2.09715e+06  R       some proc
```

---

cc @fancyremarker 