### PR TITLE
Support restarting from stopped container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,6 @@ test:
 	integration/docker-term-all.sh
 	integration/errors.sh
 	integration/wipe.sh
+	integration/stopped.sh
 
 .PHONY: release dist install clean-tox clean-pyc clean-build test

--- a/captain_comeback/test/activity_test_unit.py
+++ b/captain_comeback/test/activity_test_unit.py
@@ -102,6 +102,15 @@ class ActivityTestUnit(unittest.TestCase):
             re.compile(r"123\s+0\s+2097152\s+2097152\s+R\s+some proc"),
         ])
 
+    def test_no_pids(self):
+        self.q.put(RestartCgroupMessage(Cgroup("/some/foo"), []))
+        self.q.put(ExitMessage())
+        self.engine.run()
+        self.assertHasLogged("foo", [
+            "container exceeded its memory allocation",
+            "container is restarting:",
+        ])
+
     def test_restart_timeout(self):
         self.q.put(RestartTimeoutMessage(Cgroup("/some/foo"), 3))
         self.q.put(ExitMessage())

--- a/integration/errors.sh
+++ b/integration/errors.sh
@@ -11,7 +11,7 @@ echo "Status OK"
 
 echo "Checking error message on bogus restart"
 captain-comeback --restart foo 2>&1 \
-  | grep -qE "ERROR.+foo.+does not exist"
+  | grep -qE "ERROR.+foo"
 if [[ "$?" != 0 ]]; then
   echo "Restarting a bogus container did not print an error"
   exit 1

--- a/integration/stopped.sh
+++ b/integration/stopped.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+REL_HERE=$(dirname "${BASH_SOURCE}")
+HERE=$(cd "${REL_HERE}"; pwd)
+cd "$HERE"
+. lib.sh
+
+CANARY="foobar"
+
+# This test ensures that we can restart a stopped container.
+want_root
+
+echo "Test stopped restart"
+cid="$(docker create alpine sh -c "echo ${CANARY}")"
+captain-comeback --restart "$cid"
+docker wait "$cid"
+docker logs "$cid" | grep "$CANARY"
+docker rm "$cid"
+
+echo "Test stopped restart with wipe"
+cid="$(docker create alpine sh -c "echo ${CANARY}")"
+captain-comeback --wipe-fs --restart "$cid"
+docker wait "$cid"
+docker logs "$cid" | grep "$CANARY"
+docker rm "$cid"


### PR DESCRIPTION
Once the container exits, its cgroup is gone, so if we try to read its
PIDs, we'll get an error. This is problematic for two reasons:

- It means that if a container is about to exit when we get the
  notification that we should restart it, the restart will be racy and
  could fail (we've seen this with MongoDB when its gets an
  out-of-memory error back from `pwrite`).
- It means we can't use Captain Comeback to restart stopped containers,
  even if we want to take advantage of its "wipe the FS first"
  functionality.

This fixes both issues by ensuring restarts will succeed even if the
container wasn't even started in the first place.

---

cc @fancyremarker 