### PR TITLE
Extract restart logic into pluggable adapters (Container Restarts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,16 @@ clean-pyc:
 clean-tox:
 	rm -rf .tox/
 
-test:
+integration/hog: integration/hog.c
+	gcc integration/hog.c -Wl,--no-export-dynamic -static -o integration/hog
+
+noswap:
+	integration/noswap.sh
+
+unit: integration/hog noswap
 	python setup.py nosetests
+
+integration: install integration/hog noswap
 	integration/test.sh
 	integration/ignore.sh
 	integration/restart.sh
@@ -35,4 +43,6 @@ test:
 	integration/wipe.sh
 	integration/stopped.sh
 
-.PHONY: release dist install clean-tox clean-pyc clean-build test
+test: unit integration
+
+.PHONY: release dist install clean-tox clean-pyc clean-build test noswap unit integration

--- a/captain_comeback/restart/adapter/docker.py
+++ b/captain_comeback/restart/adapter/docker.py
@@ -1,0 +1,49 @@
+import subprocess
+import logging
+import time
+
+logger = logging.getLogger()
+
+DOCKER_FATAL_ERRORS = [
+    "No such container",
+    "no such id",
+]
+
+
+def restart(cg):
+    try_docker(cg, "docker", "stop", "-t", "0", cg.name())
+    if not try_docker(cg, "docker", "restart", "-t", "0", cg.name()):
+        raise Exception("docker restart failed")
+
+
+def try_docker(cg, *command):
+    retry_schedule = [0, 2, 5, 10]
+
+    while retry_schedule:
+        sleep_for = retry_schedule.pop(0)
+        if sleep_for:
+            logger.error("%s: wait %d seconds before retrying",
+                         cg.name(), sleep_for)
+            time.sleep(sleep_for)
+
+        proc = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        out, err = [x.decode("utf-8").strip() for x in proc.communicate()]
+        ret = proc.poll()
+
+        if ret == 0:
+            return True
+
+        logger.error("%s: failed: %s", cg.name(), str(command))
+        logger.error("%s: status: %s", cg.name(), ret)
+        logger.error("%s: stdout: %s", cg.name(), out)
+        logger.error("%s: stderr: %s", cg.name(), err)
+
+        if any(e in err for e in DOCKER_FATAL_ERRORS):
+            logger.error("%s: fatal error: no more retries", cg.name())
+            break
+
+    logger.error("%s: failed after all retries", cg.name())
+    return False

--- a/captain_comeback/restart/adapter/docker_wipe_fs.py
+++ b/captain_comeback/restart/adapter/docker_wipe_fs.py
@@ -1,0 +1,93 @@
+import os
+import logging
+import uuid
+import errno
+
+from captain_comeback.restart.adapter.docker import try_docker
+
+logger = logging.getLogger()
+
+
+AUFS_BASE_DIR = "/var/lib/docker/aufs"
+
+AUFS_DIFF_DIR = os.path.join(AUFS_BASE_DIR, "diff")
+AUFS_MNT_DIR = os.path.join(AUFS_BASE_DIR, "mnt")
+
+AUFS_MOUNTS_DIR = "/var/lib/docker/image/aufs/layerdb/mounts"
+AUFS_MOUNT_FILE = "mount-id"
+
+BACKUP_DIR = os.path.join(AUFS_BASE_DIR, "captain-comeback-backup")
+
+
+def restart(cg):
+    stop_ok = try_docker(cg, "docker", "stop", "-t", "0", cg.name())
+
+    if stop_ok:
+        try:
+            do_wipe_fs(cg)
+        except Exception:
+            logger.exception("%s: could not wipe fs", cg.name())
+    else:
+        logger.warning("%s: not wiping fs: stop failed", cg.name())
+
+    ok = try_docker(cg, "docker", "restart", "-t", "0", cg.name())
+    if not ok:
+        raise Exception("docker restart failed")
+
+
+def do_wipe_fs(cg):
+    aufs_id = cg.name()
+    mount_id_path = os.path.join(AUFS_MOUNTS_DIR, cg.name(), AUFS_MOUNT_FILE)
+    restore_id = "cc-{0}".format(uuid.uuid4())
+
+    logger.info("%s: wipe with restore id: %s", cg.name(), restore_id)
+
+    try:
+        with open(mount_id_path) as f:
+            aufs_id = f.read()
+    except (IOError, OSError):
+        # Older Docker version, no mount ID
+        logger.warning("%s: mount ID not found at: %s",
+                       cg.name(), mount_id_path)
+
+    # Check that the mount directory is empty. We stopped the container, so it
+    # should be, but if it's not, we should bail now or risk bricking the
+    # container.
+    aufs_mnt = os.path.join(AUFS_MNT_DIR, aufs_id)
+    if os.listdir(aufs_mnt):
+        raise Exception("abort wipe: mnt is not empty: %s", aufs_mnt)
+
+    aufs_container = os.path.join(AUFS_DIFF_DIR, aufs_id)
+    aufs_outbound = os.path.join(AUFS_DIFF_DIR, "-".join([restore_id, "out"]))
+    aufs_inbound = os.path.join(AUFS_DIFF_DIR, "-".join([restore_id, "in"]))
+    os.mkdir(aufs_inbound, 0o755)
+
+    # This is the "critical section". If Docker tries to access the container
+    # while we're swapping these two directories (which is NOT atomic), then
+    # we'll have bricked the container (we won't have lost any data, though, so
+    # all in all we failed to make things better but we did not actively make
+    # anything worse).
+    logger.info("%s: rename: start: %s", cg.name(), restore_id)
+    os.rename(aufs_container, aufs_outbound)
+    try:
+        os.rename(aufs_inbound, aufs_container)
+    except Exception:
+        os.rename(aufs_outbound, aufs_container)
+        raise
+    logger.info("%s: rename: done: %s", cg.name(), restore_id)
+
+    backup = os.path.join(BACKUP_DIR, "{0}-{1}".format(cg.name(), restore_id))
+    logger.info("%s: backup to: %s", cg.name(), backup)
+
+    mkdir_p(os.path.dirname(backup))
+    os.rename(aufs_outbound, backup)
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise

--- a/captain_comeback/restart/adapter/null.py
+++ b/captain_comeback/restart/adapter/null.py
@@ -1,0 +1,7 @@
+import logging
+
+logger = logging.getLogger()
+
+
+def restart(cg):
+    logger.warn("%s: not restarting", cg.name())

--- a/captain_comeback/restart/engine.py
+++ b/captain_comeback/restart/engine.py
@@ -3,10 +3,8 @@ import os
 import signal
 import logging
 import threading
-import subprocess
 import time
 import errno
-import uuid
 
 import psutil
 
@@ -15,33 +13,17 @@ from captain_comeback.restart.messages import (RestartRequestedMessage,
 from captain_comeback.activity.messages import (RestartCgroupMessage,
                                                 RestartTimeoutMessage)
 
-AUFS_BASE_DIR = "/var/lib/docker/aufs"
-
-AUFS_DIFF_DIR = os.path.join(AUFS_BASE_DIR, "diff")
-AUFS_MNT_DIR = os.path.join(AUFS_BASE_DIR, "mnt")
-
-AUFS_MOUNTS_DIR = "/var/lib/docker/image/aufs/layerdb/mounts"
-AUFS_MOUNT_FILE = "mount-id"
-
-BACKUP_DIR = os.path.join(AUFS_BASE_DIR, "captain-comeback-backup")
-
-DOCKER_FATAL_ERRORS = [
-    "No such container",
-    "no such id",
-]
-
-
 logger = logging.getLogger()
 
 RESTART_STATE_POLLS = 20
 
 
 class RestartEngine(object):
-    def __init__(self, grace_period, job_queue, activity_queue, wipe_fs):
+    def __init__(self, adapter, grace_period, job_queue, activity_queue):
+        self.adapter = adapter
         self.grace_period = grace_period
         self.job_queue = job_queue
         self.activity_queue = activity_queue
-        self.wipe_fs = wipe_fs
         self._counter = 0
         self._running_restarts = set()
 
@@ -54,8 +36,8 @@ class RestartEngine(object):
 
         job_name = "restart-job-{0}".format(self._counter)
         self._counter += 1
-        args = (self.grace_period, self.wipe_fs, cg, self.job_queue,
-                self.activity_queue)
+        args = (self.adapter, self.grace_period, cg,
+                self.job_queue, self.activity_queue)
 
         t = threading.Thread(target=restart, name=job_name, args=args)
 
@@ -86,9 +68,9 @@ class RestartEngine(object):
                 raise Exception("Unexpected message: {0}".format(message))
 
 
-def restart(grace_period, wipe_fs, cg, job_queue, activity_queue):
+def restart(adapter, grace_period, cg, job_queue, activity_queue):
     try:
-        do_restart(grace_period, wipe_fs, cg, job_queue, activity_queue)
+        do_restart(adapter, grace_period, cg, job_queue, activity_queue)
     except:
         logger.exception("%s: restart failed", cg.name())
         raise
@@ -98,7 +80,7 @@ def restart(grace_period, wipe_fs, cg, job_queue, activity_queue):
         job_queue.put(RestartCompleteMessage(cg))
 
 
-def do_restart(grace_period, wipe_fs, cg, job_queue, activity_queue):
+def do_restart(adapter, grace_period, cg, job_queue, activity_queue):
     # Snapshot task usage
     logger.info("%s: restarting", cg.name())
 
@@ -119,19 +101,7 @@ def do_restart(grace_period, wipe_fs, cg, job_queue, activity_queue):
     # It's possible that between the two steps, the container will have
     # exited already, but Docker will do the right thing and restart our
     # process in this case.
-    try:
-        for pid in cg.pids():
-            try:
-                os.kill(pid, signal.SIGTERM)
-            except OSError as e:
-                if e.errno == errno.ESRCH:
-                    # That process exited already. Who cares? We don't.
-                    logger.debug("%s: %s had already exited", cg.name(), pid)
-                else:
-                    logger.error("%s: failed to deliver SIGTERM to %s: %s",
-                                 cg.name(), pid, e)
-    except EnvironmentError as e:
-        logger.error("%s: could not signal processes: %s", cg.name(), e)
+    signal_cg(cg, signal.SIGTERM)
 
     signaled_at = time.time()
 
@@ -174,113 +144,32 @@ def do_restart(grace_period, wipe_fs, cg, job_queue, activity_queue):
                 "%s: container did not exit within %s seconds grace period",
                 cg.name(), grace_period)
             activity_queue.put(RestartTimeoutMessage(cg, grace_period))
+
+            # Should have exited when you had the chance!
+            logger.info("%s: sending SIGKILL ", cg.name())
+            signal_cg(cg, signal.SIGKILL)
     except EnvironmentError:
         # This could happen if e.g. attempting to write to the memory limit
         # file after the cgroup has exited.
         pass
 
-    stop_ok = try_docker(cg, "docker", "stop", "-t", "0", cg.name())
+    # Notify the adapter about the restart
+    adapter.restart(cg)
 
-    if wipe_fs:
-        if stop_ok:
+
+def signal_cg(cg, signum):
+    logger.info("%s: signalling with %d", cg.name(), signum)
+    try:
+        for pid in cg.pids():
             try:
-                do_wipe_fs(cg)
-            except Exception:
-                logger.exception("%s: could not wipe fs", cg.name())
-        else:
-            logger.warn("%s: not wiping fs: stop failed", cg.name())
-
-    ok = try_docker(cg, "docker", "restart", "-t", "0", cg.name())
-    if not ok:
-        raise Exception("docker restart failed")
-
-
-def do_wipe_fs(cg):
-    aufs_id = cg.name()
-    mount_id_path = os.path.join(AUFS_MOUNTS_DIR, cg.name(), AUFS_MOUNT_FILE)
-    restore_id = "cc-{0}".format(uuid.uuid4())
-
-    logger.info("%s: wipe with restore id: %s", cg.name(), restore_id)
-
-    try:
-        with open(mount_id_path) as f:
-            aufs_id = f.read()
-    except (IOError, OSError):
-        # Older Docker version, no mount ID
-        logger.warn("%s: mount ID not found at: %s",
-                    cg.name(), mount_id_path)
-
-    # Check that the mount directory is empty. We stopped the container, so it
-    # should be, but if it's not, we should bail now or risk bricking the
-    # container.
-    aufs_mnt = os.path.join(AUFS_MNT_DIR, aufs_id)
-    if os.listdir(aufs_mnt):
-        raise Exception("abort wipe: mnt is not empty: %s", aufs_mnt)
-
-    aufs_container = os.path.join(AUFS_DIFF_DIR, aufs_id)
-    aufs_outbound = os.path.join(AUFS_DIFF_DIR, "-".join([restore_id, "out"]))
-    aufs_inbound = os.path.join(AUFS_DIFF_DIR, "-".join([restore_id, "in"]))
-    os.mkdir(aufs_inbound, 0o755)
-
-    # This is the "critical section". If Docker tries to access the container
-    # while we're swapping these two directories (which is NOT atomic), then
-    # we'll have bricked the container (we won't have lost any data, though, so
-    # all in all we failed to make things better but we did not actively make
-    # anything worse).
-    logger.info("%s: rename: start: %s", cg.name(), restore_id)
-    os.rename(aufs_container, aufs_outbound)
-    try:
-        os.rename(aufs_inbound, aufs_container)
-    except Exception:
-        os.rename(aufs_outbound, aufs_container)
-        raise
-    logger.info("%s: rename: done: %s", cg.name(), restore_id)
-
-    backup = os.path.join(BACKUP_DIR, "{0}-{1}".format(cg.name(), restore_id))
-    logger.info("%s: backup to: %s", cg.name(), backup)
-
-    mkdir_p(os.path.dirname(backup))
-    os.rename(aufs_outbound, backup)
-
-
-def try_docker(cg, *command):
-    retry_schedule = [0, 2, 5, 10]
-
-    while retry_schedule:
-        sleep_for = retry_schedule.pop(0)
-        if sleep_for:
-            logger.error("%s: wait %d seconds before retrying",
-                         cg.name(), sleep_for)
-            time.sleep(sleep_for)
-
-        proc = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-
-        out, err = [x.decode("utf-8").strip() for x in proc.communicate()]
-        ret = proc.poll()
-
-        if ret == 0:
-            return True
-
-        logger.error("%s: failed: %s", cg.name(), str(command))
-        logger.error("%s: status: %s", cg.name(), ret)
-        logger.error("%s: stdout: %s", cg.name(), out)
-        logger.error("%s: stderr: %s", cg.name(), err)
-
-        if any(e in err for e in DOCKER_FATAL_ERRORS):
-            logger.error("%s: fatal error: no more retries", cg.name())
-            break
-
-    logger.error("%s: failed after all retries", cg.name())
-    return False
-
-
-def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as e:
-        if e.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
+                logger.debug("%s: deliver %d to %d", cg.name(), signum, pid)
+                os.kill(pid, signum)
+            except OSError as e:
+                if e.errno == errno.ESRCH:
+                    # That process exited already. Who cares? We don't.
+                    logger.debug("%s: %s had already exited", cg.name(), pid)
+                else:
+                    logger.error("%s: failed to deliver %d to %s: %s",
+                                 signum, cg.name(), pid, e)
+    except EnvironmentError as e:
+        logger.error("%s: could not signal processes: %s", cg.name(), e)

--- a/captain_comeback/test/docker_test_unit.py
+++ b/captain_comeback/test/docker_test_unit.py
@@ -5,10 +5,10 @@ import shutil
 import time
 
 from captain_comeback.cgroup import Cgroup
-from captain_comeback.restart import engine
+from captain_comeback.restart.adapter import docker
 
 
-class EngineTestUnit(unittest.TestCase):
+class DockerTestUnit(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
 
@@ -24,7 +24,7 @@ class EngineTestUnit(unittest.TestCase):
                 'fi'.format(test_file, test_file)
 
         cmd = ['sh', '-c', shell]
-        ret = engine.try_docker(Cgroup("/some/foo"), *cmd)
+        ret = docker.try_docker(Cgroup("/some/foo"), *cmd)
         self.assertTrue(ret)
 
     def test_try_docker_without_retry(self):
@@ -36,12 +36,12 @@ class EngineTestUnit(unittest.TestCase):
                 'fi'.format(test_file, test_file)
 
         cmd = ['sh', '-c', shell]
-        ret = engine.try_docker(Cgroup("/some/foo"), *cmd)
+        ret = docker.try_docker(Cgroup("/some/foo"), *cmd)
         self.assertTrue(ret)
 
     def test_try_docker_and_wait_fatal(self):
         t0 = time.time()
         cmd = ['docker', 'restart', 'foobar']
-        ret = engine.try_docker(Cgroup("/some/foo"), *cmd)
+        ret = docker.try_docker(Cgroup("/some/foo"), *cmd)
         self.assertFalse(ret)
         self.assertLess(time.time() - t0, 1)

--- a/integration/lib.sh
+++ b/integration/lib.sh
@@ -14,15 +14,11 @@ want_root() {
 }
 
 want_noswap() {
-  local swap_total="$(grep "SwapTotal" /proc/meminfo)"
-  if [[ ! "$swap_total" =~ SwapTotal:.+0\ kB ]]; then
-    echo "You must disable swap to run this test"
-    exit 1
-  fi
+  true
 }
 
 want_hog() {
-  gcc hog.c -Wl,--no-export-dynamic -static -o hog
+  test -f hog
 }
 
 

--- a/integration/noswap.sh
+++ b/integration/noswap.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+swap_total="$(grep "SwapTotal" /proc/meminfo)"
+
+if [[ ! "$swap_total" =~ SwapTotal:.+0\ kB ]]; then
+  echo "You must disable swap to run tests"
+  exit 1
+fi

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     packages=[
         'captain_comeback',
         'captain_comeback.restart',
+        'captain_comeback.restart.adapter',
         'captain_comeback.activity',
         'captain_comeback.test'
     ],


### PR DESCRIPTION
This exposes a new `--restart-adapter` option, which can be used to
configure an arbitrary adapter to restart containers. We'll use this to
coordinate restarts via Sweetness.

With a default configuration, there are no functional changes here, with
the exception that Captain Comeback will now deliver a `SIGKILL` if the
container does not exit in time, whereas until now we had relied on
`docker stop ...` to do so (we still run `docker stop`, though).

---

cc @fancyremarker 