### PR TITLE
Log memory.stat from cgroup at under_oom

### DIFF
--- a/captain_comeback/test/cgroup_test_integration.py
+++ b/captain_comeback/test/cgroup_test_integration.py
@@ -494,3 +494,9 @@ class CgroupTestIntegration(unittest.TestCase, QueueAssertionHelper):
             self.assertIsInstance(proc["memory_info"].rss, int)
             self.assertIsInstance(proc["cmdline"], list)
             self.assertIn(proc["status"], PROC_STATUSES_RAW.keys())
+
+    def test_memory_stat(self):
+        cg_path = create_random_cg(self.parent_cg_path)
+        cg = Cgroup(cg_path)
+        lines = cg.memory_stat_lines()
+        self.assertEqual("cache 0", lines[0])


### PR DESCRIPTION
This will provide more visibility into memory when the Kernel asks us to
free memory in a cgroup. In particular, we'd like to confirm that the
Kernel is able to reclaim cache pages before returning with `ENOMEM` on
a syscall.

---

cc @fancyremarker 