### PR TITLE
Monitor eventfd for critical memory pressure

### DIFF
--- a/captain_comeback/test/queue_assertion_helper.py
+++ b/captain_comeback/test/queue_assertion_helper.py
@@ -14,5 +14,19 @@ class QueueAssertionHelper(object):
         for k, v in attrs.items():
             self.assertEqual(v, getattr(msg, k))
 
+    def assertEvnetuallyHasMessageForCg(self, *args, **kwargs):
+        for i in range(100):
+            yield
+
+            try:
+                self.assertHasMessageForCg(*args, **kwargs)
+            except AssertionError:
+                pass
+            else:
+                break
+        else:
+            self.assertHasMessageForCg(*args, **kwargs)
+
+
     def assertHasNoMessages(self, q):
         self.assertRaises(queue.Empty, q.get_nowait)


### PR DESCRIPTION
This might give us an advance warning that the system is about to run
out of memory, but needs testing.

At a glance, critical is reached about the same time as regular OOM for
RSS-caused evictions. The idea here is to deploy this and monitor when
it's reached in more subtle scenarios (e.g. lots of caches, etc.).

See: https://lwn.net/Articles/544652/

---

cc @fancyremarker 