### PR TITLE
fsync on memory pressure

### DIFF
--- a/captain_comeback/cgroup.py
+++ b/captain_comeback/cgroup.py
@@ -5,7 +5,8 @@ import logging
 import linuxfd
 import psutil
 
-from captain_comeback.restart.messages import RestartRequestedMessage
+from captain_comeback.restart.messages import (RestartRequestedMessage,
+                                               MemoryPressureMessage)
 
 logger = logging.getLogger()
 
@@ -119,6 +120,8 @@ class Cgroup(object):
                     "%s: under_pressure ? (? / ?)",
                     self.name()
                 )
+
+            job_queue.put(MemoryPressureMessage(self))
 
             return
 

--- a/captain_comeback/restart/messages.py
+++ b/captain_comeback/restart/messages.py
@@ -11,3 +11,8 @@ class RestartRequestedMessage(object):
 class RestartCompleteMessage(object):
     def __init__(self, cg):
         self.cg = cg
+
+
+class MemoryPressureMessage(object):
+    def __init__(self, cg):
+        self.cg = cg


### PR DESCRIPTION
In our testing, it appears memory pressure on a cgroup can result from
dirty pages that have not been committed to disk yet. In worst cases,
this can cause the cgroup to run out of RAM even with minimal RSS usage.

It also appears that we get the memory pressure notification a few
seconds before the cgroup will run out of RAM (and before e.g. eCryptfs
operations might return errors). So, if we attempt to fsync just as we
get the memory pressure notification, we might be able to avoid a cgroup
OOM altogether.

This patch implements that.

---

cc @fancyremarker 